### PR TITLE
Correction des chemins de redirection dans le questionnaire candidat

### DIFF
--- a/static/services/proposals.js
+++ b/static/services/proposals.js
@@ -221,9 +221,11 @@ function renderJobProposals() {
 // Fonction pour rediriger vers la page des propositions après le questionnaire
 function redirectToProposals(userType) {
     if (userType === 'candidate') {
-        window.location.href = '../templates/candidate-jobs-proposals.html';
+        // Correction du chemin de redirection pour GitHub Pages
+        window.location.href = 'candidate-jobs-proposals.html';
     } else if (userType === 'recruiter') {
-        window.location.href = '../templates/recruiter-candidates-proposals.html';
+        // Correction du chemin de redirection pour GitHub Pages
+        window.location.href = 'recruiter-candidates-proposals.html';
     }
 }
 


### PR DESCRIPTION
## Description du problème

Le formulaire de questionnaire candidat présente un problème de redirection après sa soumission. Le bug se trouve dans la fonction `redirectToProposals()` du fichier `static/services/proposals.js`.

Le problème vient du chemin relatif utilisé pour la redirection :
- La fonction utilise `../templates/candidate-jobs-proposals.html`
- Comme la page est déjà dans le dossier `/templates`, ce chemin relatif crée une redirection incorrecte

## Solution

J'ai modifié la fonction `redirectToProposals()` pour utiliser des chemins relatifs simples :
- Pour les candidats : `candidate-jobs-proposals.html`
- Pour les recruteurs : `recruiter-candidates-proposals.html`

Ces modifications garantissent que la redirection fonctionne correctement, notamment dans l'environnement GitHub Pages.

## Test

Après cette correction, lorsqu'un candidat termine le questionnaire et clique sur le bouton de soumission, il sera correctement redirigé vers la page des propositions de postes.
