### PR TITLE
Fix: Update pydantic import to use pydantic_settings

### DIFF
--- a/cv-parser-service/app/core/config.py
+++ b/cv-parser-service/app/core/config.py
@@ -1,7 +1,7 @@
 # CV Parser Service - Configuration
 
 import os
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings, Field
 from typing import Optional, Dict, Any, List
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Description
Cette PR corrige le problème d'importation dans `config.py` en mettant à jour l'import de Pydantic.

## Changements
- Remplacé `from pydantic import BaseSettings, Field` par `from pydantic_settings import BaseSettings, Field`

## Contexte
Dans les versions récentes de Pydantic, les classes de configuration ont été déplacées dans un package séparé `pydantic-settings`. Cette modification permet de résoudre l'erreur d'importation lors du démarrage du service cv-parser.

## Tests
Cette modification devrait permettre au service de démarrer correctement sans erreur d'importation.