### PR TITLE
Fix: Résoudre les problèmes de compatibilité Pydantic

### DIFF
--- a/job-parser-service/README-fix.md
+++ b/job-parser-service/README-fix.md
@@ -1,0 +1,33 @@
+# Corrections pour les problèmes de compatibilité Pydantic
+
+Ce patch résout les problèmes de compatibilité entre Pydantic v1 et v2, en particulier l'erreur :
+
+```
+pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package.
+```
+
+## Modifications apportées
+
+1. Copie du module `pydantic_compat.py` dans le répertoire `app/core/` pour assurer qu'il est accessible directement depuis les modules core.
+
+2. Modification des importations dans `config.py` pour utiliser plusieurs niveaux de fallback :
+   - D'abord, essayer d'importer depuis le module local
+   - Ensuite, essayer d'importer depuis le module à la racine
+   - Ensuite, essayer d'importer directement depuis pydantic-settings
+   - Enfin, fallback vers l'ancienne approche pydantic v1
+
+3. Ajout d'un script `restart-job-parser.sh` pour faciliter le redémarrage après modifications.
+
+## Comment utiliser
+
+1. Assurez-vous que votre .env contient une clé API OpenAI valide
+2. Rendez le script exécutable : `chmod +x restart-job-parser.sh`
+3. Exécutez le script : `./restart-job-parser.sh`
+
+## Autres problèmes potentiels
+
+Si vous rencontrez d'autres erreurs liées à Pydantic, vérifiez que :
+
+1. Les versions des packages dans requirements.txt sont compatibles
+2. Docker a bien accès à tous les fichiers nécessaires
+3. Les configurations dans .env sont correctes

--- a/job-parser-service/app/core/config.py
+++ b/job-parser-service/app/core/config.py
@@ -6,8 +6,22 @@ import logging
 from typing import Any, Dict, Optional
 
 # Utilisation du module de compatibilité pour Pydantic v1 et v2
-from pydantic_compat import BaseSettings
-from pydantic import validator
+try:
+    # Essayer avec la version locale
+    from app.core.pydantic_compat import BaseSettings
+    from pydantic import validator
+except ImportError:
+    try:
+        # Essayer avec le module à la racine
+        from pydantic_compat import BaseSettings
+        from pydantic import validator
+    except ImportError:
+        # Fallback direct pour les versions plus anciennes
+        try:
+            from pydantic_settings import BaseSettings
+            from pydantic import validator
+        except ImportError:
+            from pydantic import BaseSettings, validator
 
 class Settings(BaseSettings):
     """Paramètres de configuration du service"""

--- a/job-parser-service/app/core/pydantic_compat.py
+++ b/job-parser-service/app/core/pydantic_compat.py
@@ -1,0 +1,34 @@
+"""
+Module de compatibilité pour Pydantic v1 et v2.
+Permet d'utiliser le code avec les deux versions de Pydantic.
+"""
+import sys
+import importlib.util
+import logging
+
+logger = logging.getLogger(__name__)
+
+def is_pydantic_v2():
+    """Vérifie si Pydantic v2 est installé"""
+    import pydantic
+    return pydantic.__version__.startswith('2')
+
+# Classes et fonctions compatibles avec les deux versions
+def get_base_settings():
+    """Retourne la classe BaseSettings appropriée selon la version de Pydantic"""
+    if is_pydantic_v2():
+        try:
+            from pydantic_settings import BaseSettings
+            logger.info("Utilisation de BaseSettings depuis pydantic_settings (Pydantic v2)")
+            return BaseSettings
+        except ImportError:
+            logger.warning("pydantic_settings non trouvé, utilisation de la classe BaseSettings de Pydantic v1")
+            from pydantic import BaseSettings
+            return BaseSettings
+    else:
+        from pydantic import BaseSettings
+        logger.info("Utilisation de BaseSettings depuis pydantic (Pydantic v1)")
+        return BaseSettings
+
+# Exporter les classes et fonctions
+BaseSettings = get_base_settings()


### PR DESCRIPTION
## Description

Cette PR résout les problèmes de compatibilité entre Pydantic v1 et v2, en particulier l'erreur rencontrée lors du démarrage du service job-parser :

```
pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package.
```

## Modifications

1. **Ajout de `pydantic_compat.py` dans `app/core/`** - Pour assurer que ce module est accessible directement depuis les modules core.

2. **Modification de `config.py`** - Utilisation de plusieurs niveaux de fallback pour les importations :
   - Essai d'import depuis le module local
   - Essai d'import depuis le module à la racine
   - Essai d'import direct depuis pydantic-settings
   - Fallback vers l'ancienne approche pydantic v1

3. **Ajout d'un script `restart-job-parser.sh`** - Pour faciliter le redémarrage du service après modifications.

4. **Documentation** - Ajout d'un README-fix.md pour expliquer les changements.

## Comment tester

1. Assurez-vous que votre fichier `.env` contient une clé API OpenAI valide
2. Rendez le script exécutable : `chmod +x restart-job-parser.sh`
3. Exécutez le script : `./restart-job-parser.sh`
4. Vérifiez que le service démarre correctement et que le endpoint de santé répond : `curl http://localhost:5053/health`
5. Testez le parsing d'une fiche de poste : `./curl-test-job-parser.sh ~/chemin/vers/fichedeposte.pdf`

## Notes

Cette correction maintient la compatibilité avec les deux versions de Pydantic tout en s'assurant que le service démarre correctement.