### PR TITLE
Correction de l'erreur d'indentation dans config.py

### DIFF
--- a/fix-job-parser.sh
+++ b/fix-job-parser.sh
@@ -74,9 +74,84 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 1
 fi
 
-# Modifier le fichier config.py
+# Remplacer le fichier config.py entier plutôt que de modifier avec sed
+# Cela évite les problèmes d'indentation
 log_message "Modification du fichier config.py pour utiliser pydantic_compat..."
-sed -i.bak 's/from pydantic import BaseSettings/try:\n    from app.core.pydantic_compat import BaseSettings\n    from pydantic import validator\nexcept ImportError:\n    try:\n        from pydantic_settings import BaseSettings\n        from pydantic import validator\n    except ImportError:\n        from pydantic import BaseSettings, validator/g' "$CONFIG_FILE"
+cat > "$CONFIG_FILE" << 'EOLL'
+"""
+Configuration centrale pour le service de parsing de fiches de poste.
+"""
+import os
+import logging
+from typing import Any, Dict, Optional
+
+# Utilisation du module de compatibilité pour Pydantic v1 et v2
+try:
+    # Essayer avec la version locale
+    from app.core.pydantic_compat import BaseSettings
+    from pydantic import validator
+except ImportError:
+    try:
+        # Essayer avec le module à la racine
+        from pydantic_settings import BaseSettings
+        from pydantic import validator
+    except ImportError:
+        # Fallback direct pour les versions plus anciennes
+        from pydantic import BaseSettings, validator
+
+class Settings(BaseSettings):
+    """Paramètres de configuration du service"""
+    
+    # API Keys et configurations externes
+    OPENAI_API_KEY: Optional[str] = os.environ.get('OPENAI_API_KEY') or os.environ.get('OPENAI')
+    OPENAI_MODEL: str = os.environ.get('OPENAI_MODEL') or 'gpt-4o-mini'
+    
+    # Configuration Redis (pour les files d'attente)
+    REDIS_HOST: str = os.environ.get('REDIS_HOST') or 'localhost'
+    REDIS_PORT: int = int(os.environ.get('REDIS_PORT') or 6379)
+    REDIS_DB: int = int(os.environ.get('REDIS_DB') or 0)
+    REDIS_PASSWORD: Optional[str] = os.environ.get('REDIS_PASSWORD')
+    
+    # Configuration MinIO (pour le stockage de fichiers)
+    MINIO_ENDPOINT: str = os.environ.get('MINIO_ENDPOINT') or 'localhost:9000'
+    MINIO_ACCESS_KEY: str = os.environ.get('MINIO_ACCESS_KEY') or 'minioadmin'
+    MINIO_SECRET_KEY: str = os.environ.get('MINIO_SECRET_KEY') or 'minioadmin'
+    MINIO_SECURE: bool = os.environ.get('MINIO_SECURE', '').lower() == 'true'
+    
+    # Configuration de l'API
+    API_V1_STR: str = "/api"
+    SERVICE_NAME: str = "job-parser-service"
+    
+    # Configuration du service
+    UPLOAD_FOLDER: str = "uploads"
+    MAX_CONTENT_LENGTH: int = 10 * 1024 * 1024  # 10MB
+    ALLOWED_EXTENSIONS: set = {'pdf', 'doc', 'docx', 'txt', 'rtf'}
+    
+    # Mode de simulation/test
+    USE_MOCK_PARSER: bool = os.environ.get('USE_MOCK_PARSER', '').lower() == 'true'
+    
+    # Validation des paramètres
+    @validator('OPENAI_API_KEY')
+    def validate_openai_api_key(cls, v, values, **kwargs):
+        """Valide la clé API OpenAI"""
+        if not v and not values.get('USE_MOCK_PARSER'):
+            logging.warning("Aucune clé API OpenAI n'a été fournie. Le service utilisera le mode de simulation par défaut.")
+            values['USE_MOCK_PARSER'] = True
+        return v
+    
+    class Config:
+        case_sensitive = True
+        env_file = ".env"
+
+# Créer une instance des paramètres
+settings = Settings()
+
+# Si aucune clé API n'est définie et que le mode mock n'est pas explicitement activé, 
+# activer le mode mock automatiquement
+if not settings.OPENAI_API_KEY and not settings.USE_MOCK_PARSER:
+    logging.warning("Aucune clé API OpenAI trouvée. Activation automatique du mode de simulation (mock).")
+    settings.USE_MOCK_PARSER = True
+EOLL
 
 # Vérifier si pydantic-settings est installé
 log_message "Vérification de l'installation de pydantic-settings..."
@@ -97,15 +172,145 @@ echo "Application des corrections sur les conteneurs..."
 docker cp /tmp/entrypoint.sh.new nexten-job-parser:/entrypoint.sh
 docker exec nexten-job-parser chmod +x /entrypoint.sh
 
+# Créer config.py corrigé
+cat > /tmp/config.py.fixed << 'EOL'
+"""
+Configuration centrale pour le service de parsing de fiches de poste.
+"""
+import os
+import logging
+from typing import Any, Dict, Optional
+
+# Utilisation du module de compatibilité pour Pydantic v1 et v2
+try:
+    # Essayer avec la version locale
+    from app.core.pydantic_compat import BaseSettings
+    from pydantic import validator
+except ImportError:
+    try:
+        # Essayer avec le module à la racine
+        from pydantic_settings import BaseSettings
+        from pydantic import validator
+    except ImportError:
+        # Fallback direct pour les versions plus anciennes
+        from pydantic import BaseSettings, validator
+
+class Settings(BaseSettings):
+    """Paramètres de configuration du service"""
+    
+    # API Keys et configurations externes
+    OPENAI_API_KEY: Optional[str] = os.environ.get('OPENAI_API_KEY') or os.environ.get('OPENAI')
+    OPENAI_MODEL: str = os.environ.get('OPENAI_MODEL') or 'gpt-4o-mini'
+    
+    # Configuration Redis (pour les files d'attente)
+    REDIS_HOST: str = os.environ.get('REDIS_HOST') or 'localhost'
+    REDIS_PORT: int = int(os.environ.get('REDIS_PORT') or 6379)
+    REDIS_DB: int = int(os.environ.get('REDIS_DB') or 0)
+    REDIS_PASSWORD: Optional[str] = os.environ.get('REDIS_PASSWORD')
+    
+    # Configuration MinIO (pour le stockage de fichiers)
+    MINIO_ENDPOINT: str = os.environ.get('MINIO_ENDPOINT') or 'localhost:9000'
+    MINIO_ACCESS_KEY: str = os.environ.get('MINIO_ACCESS_KEY') or 'minioadmin'
+    MINIO_SECRET_KEY: str = os.environ.get('MINIO_SECRET_KEY') or 'minioadmin'
+    MINIO_SECURE: bool = os.environ.get('MINIO_SECURE', '').lower() == 'true'
+    
+    # Configuration de l'API
+    API_V1_STR: str = "/api"
+    SERVICE_NAME: str = "job-parser-service"
+    
+    # Configuration du service
+    UPLOAD_FOLDER: str = "uploads"
+    MAX_CONTENT_LENGTH: int = 10 * 1024 * 1024  # 10MB
+    ALLOWED_EXTENSIONS: set = {'pdf', 'doc', 'docx', 'txt', 'rtf'}
+    
+    # Mode de simulation/test
+    USE_MOCK_PARSER: bool = os.environ.get('USE_MOCK_PARSER', '').lower() == 'true'
+    
+    # Validation des paramètres
+    @validator('OPENAI_API_KEY')
+    def validate_openai_api_key(cls, v, values, **kwargs):
+        """Valide la clé API OpenAI"""
+        if not v and not values.get('USE_MOCK_PARSER'):
+            logging.warning("Aucune clé API OpenAI n'a été fournie. Le service utilisera le mode de simulation par défaut.")
+            values['USE_MOCK_PARSER'] = True
+        return v
+    
+    class Config:
+        case_sensitive = True
+        env_file = ".env"
+
+# Créer une instance des paramètres
+settings = Settings()
+
+# Si aucune clé API n'est définie et que le mode mock n'est pas explicitement activé, 
+# activer le mode mock automatiquement
+if not settings.OPENAI_API_KEY and not settings.USE_MOCK_PARSER:
+    logging.warning("Aucune clé API OpenAI trouvée. Activation automatique du mode de simulation (mock).")
+    settings.USE_MOCK_PARSER = True
+EOL
+
+# Copier config.py corrigé dans le conteneur
+docker cp /tmp/config.py.fixed nexten-job-parser:/app/app/core/config.py
+
+# Créer pydantic_compat.py
+cat > /tmp/pydantic_compat.py << 'EOL'
+"""
+Module de compatibilité pour Pydantic v1 et v2.
+Permet d'utiliser le code avec les deux versions de Pydantic.
+"""
+import sys
+import importlib.util
+import logging
+
+logger = logging.getLogger(__name__)
+
+def is_pydantic_v2():
+    """Vérifie si Pydantic v2 est installé"""
+    import pydantic
+    return pydantic.__version__.startswith('2')
+
+# Classes et fonctions compatibles avec les deux versions
+def get_base_settings():
+    """Retourne la classe BaseSettings appropriée selon la version de Pydantic"""
+    if is_pydantic_v2():
+        try:
+            from pydantic_settings import BaseSettings
+            logger.info("Utilisation de BaseSettings depuis pydantic_settings (Pydantic v2)")
+            return BaseSettings
+        except ImportError:
+            logger.warning("pydantic_settings non trouvé, utilisation de la classe BaseSettings de Pydantic v1")
+            from pydantic import BaseSettings
+            return BaseSettings
+    else:
+        from pydantic import BaseSettings
+        logger.info("Utilisation de BaseSettings depuis pydantic (Pydantic v1)")
+        return BaseSettings
+
+# Exporter les classes et fonctions
+BaseSettings = get_base_settings()
+EOL
+
+# Créer le répertoire si nécessaire
+docker exec nexten-job-parser mkdir -p /app/app/core
+
+# Copier pydantic_compat.py dans le conteneur
+docker cp /tmp/pydantic_compat.py nexten-job-parser:/app/app/core/pydantic_compat.py
+
 # Appliquer aussi aux workers si nécessaire
 if docker ps | grep -q "commitment--job-parser-worker-1"; then
   docker cp /tmp/entrypoint.sh.new commitment--job-parser-worker-1:/entrypoint.sh
   docker exec commitment--job-parser-worker-1 chmod +x /entrypoint.sh
+  docker exec commitment--job-parser-worker-1 mkdir -p /app/app/core
+  docker cp /tmp/config.py.fixed commitment--job-parser-worker-1:/app/app/core/config.py
+  docker cp /tmp/pydantic_compat.py commitment--job-parser-worker-1:/app/app/core/pydantic_compat.py
 fi
 
 if docker ps | grep -q "commitment--job-parser-worker-2"; then
   docker cp /tmp/entrypoint.sh.new commitment--job-parser-worker-2:/entrypoint.sh
   docker exec commitment--job-parser-worker-2 chmod +x /entrypoint.sh
+  docker exec commitment--job-parser-worker-2 mkdir -p /app/app/core
+  docker cp /tmp/config.py.fixed commitment--job-parser-worker-2:/app/app/core/config.py
+  docker cp /tmp/pydantic_compat.py commitment--job-parser-worker-2:/app/app/core/pydantic_compat.py
 fi
 
 echo "Installation des dépendances dans le conteneur..."

--- a/job-parser-service/entrypoint.sh
+++ b/job-parser-service/entrypoint.sh
@@ -60,9 +60,84 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 1
 fi
 
-# Modifier le fichier config.py
+# Remplacer le fichier config.py entier plutôt que de modifier avec sed
+# Cela évite les problèmes d'indentation
 log_message "Modification du fichier config.py pour utiliser pydantic_compat..."
-sed -i.bak 's/from pydantic import BaseSettings/try:\n    from app.core.pydantic_compat import BaseSettings\n    from pydantic import validator\nexcept ImportError:\n    try:\n        from pydantic_settings import BaseSettings\n        from pydantic import validator\n    except ImportError:\n        from pydantic import BaseSettings, validator/g' "$CONFIG_FILE"
+cat > "$CONFIG_FILE" << 'EOL'
+"""
+Configuration centrale pour le service de parsing de fiches de poste.
+"""
+import os
+import logging
+from typing import Any, Dict, Optional
+
+# Utilisation du module de compatibilité pour Pydantic v1 et v2
+try:
+    # Essayer avec la version locale
+    from app.core.pydantic_compat import BaseSettings
+    from pydantic import validator
+except ImportError:
+    try:
+        # Essayer avec le module à la racine
+        from pydantic_settings import BaseSettings
+        from pydantic import validator
+    except ImportError:
+        # Fallback direct pour les versions plus anciennes
+        from pydantic import BaseSettings, validator
+
+class Settings(BaseSettings):
+    """Paramètres de configuration du service"""
+    
+    # API Keys et configurations externes
+    OPENAI_API_KEY: Optional[str] = os.environ.get('OPENAI_API_KEY') or os.environ.get('OPENAI')
+    OPENAI_MODEL: str = os.environ.get('OPENAI_MODEL') or 'gpt-4o-mini'
+    
+    # Configuration Redis (pour les files d'attente)
+    REDIS_HOST: str = os.environ.get('REDIS_HOST') or 'localhost'
+    REDIS_PORT: int = int(os.environ.get('REDIS_PORT') or 6379)
+    REDIS_DB: int = int(os.environ.get('REDIS_DB') or 0)
+    REDIS_PASSWORD: Optional[str] = os.environ.get('REDIS_PASSWORD')
+    
+    # Configuration MinIO (pour le stockage de fichiers)
+    MINIO_ENDPOINT: str = os.environ.get('MINIO_ENDPOINT') or 'localhost:9000'
+    MINIO_ACCESS_KEY: str = os.environ.get('MINIO_ACCESS_KEY') or 'minioadmin'
+    MINIO_SECRET_KEY: str = os.environ.get('MINIO_SECRET_KEY') or 'minioadmin'
+    MINIO_SECURE: bool = os.environ.get('MINIO_SECURE', '').lower() == 'true'
+    
+    # Configuration de l'API
+    API_V1_STR: str = "/api"
+    SERVICE_NAME: str = "job-parser-service"
+    
+    # Configuration du service
+    UPLOAD_FOLDER: str = "uploads"
+    MAX_CONTENT_LENGTH: int = 10 * 1024 * 1024  # 10MB
+    ALLOWED_EXTENSIONS: set = {'pdf', 'doc', 'docx', 'txt', 'rtf'}
+    
+    # Mode de simulation/test
+    USE_MOCK_PARSER: bool = os.environ.get('USE_MOCK_PARSER', '').lower() == 'true'
+    
+    # Validation des paramètres
+    @validator('OPENAI_API_KEY')
+    def validate_openai_api_key(cls, v, values, **kwargs):
+        """Valide la clé API OpenAI"""
+        if not v and not values.get('USE_MOCK_PARSER'):
+            logging.warning("Aucune clé API OpenAI n'a été fournie. Le service utilisera le mode de simulation par défaut.")
+            values['USE_MOCK_PARSER'] = True
+        return v
+    
+    class Config:
+        case_sensitive = True
+        env_file = ".env"
+
+# Créer une instance des paramètres
+settings = Settings()
+
+# Si aucune clé API n'est définie et que le mode mock n'est pas explicitement activé, 
+# activer le mode mock automatiquement
+if not settings.OPENAI_API_KEY and not settings.USE_MOCK_PARSER:
+    logging.warning("Aucune clé API OpenAI trouvée. Activation automatique du mode de simulation (mock).")
+    settings.USE_MOCK_PARSER = True
+EOL
 
 # Vérifier si pydantic-settings est installé
 log_message "Vérification de l'installation de pydantic-settings..."


### PR DESCRIPTION
## Description

Cette PR corrige un problème d'indentation dans le fichier `config.py` qui causait l'erreur suivante lors du démarrage du service job-parser :

```
IndentationError: expected an indented block after 'try' statement on line 24
```

## Modifications apportées

1. **Correction de l'indentation dans config.py** - Résout l'erreur d'indentation dans les blocs try/except

2. **Amélioration des scripts** - Modification de l'approche dans les scripts pour éviter les problèmes d'indentation :
   - Dans `entrypoint.sh`, remplacement de l'approche sed par un remplacement complet du fichier
   - Dans `fix-job-parser.sh`, remplacement complet des fichiers plutôt que des modifications partielles

## Comment tester

Pour appliquer cette correction rapidement dans un déploiement existant :

```bash
curl -o fix-job-parser.sh https://raw.githubusercontent.com/Bapt252/Commitment-/fix-config-indentation/fix-job-parser.sh
chmod +x fix-job-parser.sh
./fix-job-parser.sh
```

Ou avec un redémarrage complet :

```bash
git checkout main
git pull origin main
chmod +x restart-job-parser.sh
./restart-job-parser.sh
```

## Résolution du problème

Cette PR résout définitivement le problème d'indentation rencontré lors de l'utilisation de sed pour modifier le fichier config.py.